### PR TITLE
Fix pod name in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,4 +106,4 @@ Will print:
 
 ## How to install
 
-`pod 'EventKit', :git =>  "https://github.com/LastSprint/EventKit.git"`
+`pod 'Events', :git =>  "https://github.com/LastSprint/EventKit.git"`


### PR DESCRIPTION
**Changes:**
- Fixed pod name in Readme in "How to install" section